### PR TITLE
Use im::Vector for arena storage

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -13,14 +13,14 @@ use typed_generational_arena::{
 use std::hint::black_box;
 
 #[allow(dead_code)]
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct Small(usize);
 
 #[allow(dead_code)]
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct Big([usize; 32]);
 
-fn insert<T: Default>(n: usize) {
+fn insert<T: Default + Clone>(n: usize) {
     let mut arena = Arena::<T>::new();
     for _ in 0..n {
         let idx = arena.insert(Default::default());
@@ -28,19 +28,19 @@ fn insert<T: Default>(n: usize) {
     }
 }
 
-fn lookup<T>(arena: &Arena<T>, idx: Index<T>, n: usize) {
+fn lookup<T: Clone>(arena: &Arena<T>, idx: Index<T>, n: usize) {
     for _ in 0..n {
         black_box(&arena[idx]);
     }
 }
 
-fn collect<T>(arena: &Arena<T>, n: usize) {
+fn collect<T: Clone>(arena: &Arena<T>, n: usize) {
     for _ in 0..n {
         black_box(arena.iter().collect::<Vec<_>>());
     }
 }
 
-fn u32_insert<T: Default>(n: usize) {
+fn u32_insert<T: Default + Clone>(n: usize) {
     let mut arena = SmallArena::<T>::new();
     for _ in 0..n {
         let idx = arena.insert(Default::default());
@@ -48,19 +48,19 @@ fn u32_insert<T: Default>(n: usize) {
     }
 }
 
-fn u32_lookup<T>(arena: &SmallArena<T>, idx: SmallIndex<T>, n: usize) {
+fn u32_lookup<T: Clone>(arena: &SmallArena<T>, idx: SmallIndex<T>, n: usize) {
     for _ in 0..n {
         black_box(&arena[idx]);
     }
 }
 
-fn u32_collect<T>(arena: &SmallArena<T>, n: usize) {
+fn u32_collect<T: Clone>(arena: &SmallArena<T>, n: usize) {
     for _ in 0..n {
         black_box(arena.iter().collect::<Vec<_>>());
     }
 }
 
-fn slab_insert<T: Default>(n: usize) {
+fn slab_insert<T: Default + Clone>(n: usize) {
     let mut slab = Slab::<T>::new();
     for _ in 0..n {
         let idx = slab.insert(Default::default());
@@ -68,19 +68,19 @@ fn slab_insert<T: Default>(n: usize) {
     }
 }
 
-fn slab_lookup<T>(slab: &Slab<T>, idx: SlabIndex<T>, n: usize) {
+fn slab_lookup<T: Clone>(slab: &Slab<T>, idx: SlabIndex<T>, n: usize) {
     for _ in 0..n {
         black_box(&slab[idx]);
     }
 }
 
-fn slab_collect<T>(slab: &Slab<T>, n: usize) {
+fn slab_collect<T: Clone>(slab: &Slab<T>, n: usize) {
     for _ in 0..n {
         black_box(slab.iter().collect::<Vec<_>>());
     }
 }
 
-fn u32_slab_insert<T: Default>(n: usize) {
+fn u32_slab_insert<T: Default + Clone>(n: usize) {
     let mut slab = SmallSlab::<T>::new();
     for _ in 0..n {
         let idx = slab.insert(Default::default());
@@ -88,19 +88,19 @@ fn u32_slab_insert<T: Default>(n: usize) {
     }
 }
 
-fn u32_slab_lookup<T>(slab: &SmallSlab<T>, idx: SmallSlabIndex<T>, n: usize) {
+fn u32_slab_lookup<T: Clone>(slab: &SmallSlab<T>, idx: SmallSlabIndex<T>, n: usize) {
     for _ in 0..n {
         black_box(&slab[idx]);
     }
 }
 
-fn u32_slab_collect<T>(slab: &SmallSlab<T>, n: usize) {
+fn u32_slab_collect<T: Clone>(slab: &SmallSlab<T>, n: usize) {
     for _ in 0..n {
         black_box(slab.iter().collect::<Vec<_>>());
     }
 }
 
-fn ptr_slab_insert<T: Default>(n: usize) {
+fn ptr_slab_insert<T: Default + Clone>(n: usize) {
     let mut slab = PtrSlab::<T>::new();
     for _ in 0..n {
         let idx = slab.insert(Default::default());
@@ -108,19 +108,19 @@ fn ptr_slab_insert<T: Default>(n: usize) {
     }
 }
 
-fn ptr_slab_lookup<T>(slab: &PtrSlab<T>, idx: PtrSlabIndex<T>, n: usize) {
+fn ptr_slab_lookup<T: Clone>(slab: &PtrSlab<T>, idx: PtrSlabIndex<T>, n: usize) {
     for _ in 0..n {
         black_box(&slab[idx]);
     }
 }
 
-fn ptr_slab_collect<T>(slab: &PtrSlab<T>, n: usize) {
+fn ptr_slab_collect<T: Clone>(slab: &PtrSlab<T>, n: usize) {
     for _ in 0..n {
         black_box(slab.iter().collect::<Vec<_>>());
     }
 }
 
-fn u32_ptr_slab_insert<T: Default>(n: usize) {
+fn u32_ptr_slab_insert<T: Default + Clone>(n: usize) {
     let mut slab = SmallPtrSlab::<T>::new();
     for _ in 0..n {
         let idx = slab.insert(Default::default());
@@ -128,13 +128,13 @@ fn u32_ptr_slab_insert<T: Default>(n: usize) {
     }
 }
 
-fn u32_ptr_slab_lookup<T>(slab: &SmallPtrSlab<T>, idx: SmallPtrSlabIndex<T>, n: usize) {
+fn u32_ptr_slab_lookup<T: Clone>(slab: &SmallPtrSlab<T>, idx: SmallPtrSlabIndex<T>, n: usize) {
     for _ in 0..n {
         black_box(&slab[idx]);
     }
 }
 
-fn u32_ptr_slab_collect<T>(slab: &SmallPtrSlab<T>, n: usize) {
+fn u32_ptr_slab_collect<T: Clone>(slab: &SmallPtrSlab<T>, n: usize) {
     for _ in 0..n {
         black_box(slab.iter().collect::<Vec<_>>());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,14 +153,13 @@ extern crate num_traits;
 extern crate cfg_if;
 #[cfg(feature = "serde")]
 extern crate serde;
+extern crate im;
 
 cfg_if! {
     if #[cfg(feature = "std")] {
         extern crate std;
-        use std::vec::{self, Vec};
     } else {
         extern crate alloc;
-        use alloc::vec::{self, Vec};
     }
 }
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,4 +1,12 @@
-use crate::{arena::{Arena, Entry, DEFAULT_CAPACITY}, generation::GenerationalIndex, index::ArenaIndex, Vec};
+use crate::{arena::{Arena, Entry, DEFAULT_CAPACITY}, generation::GenerationalIndex, index::ArenaIndex};
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        use std::vec::Vec;
+    } else {
+        use alloc::vec::Vec;
+    }
+}
+use im::Vector;
 use core::fmt;
 use core::iter;
 use core::marker::PhantomData;
@@ -106,7 +114,7 @@ where
         }
 
         Ok(Arena {
-            items,
+            items: Vector::from(items),
             generation,
             free_list_head,
             len,

--- a/tests/clone_immutability.rs
+++ b/tests/clone_immutability.rs
@@ -1,0 +1,40 @@
+extern crate typed_generational_arena;
+use typed_generational_arena::StandardArena as Arena;
+
+#[test]
+fn snapshots_are_immutable_after_clone() {
+    let mut arena = Arena::new();
+    let snap0 = arena.clone();
+
+    let idx = arena.insert(1);
+    let snap1 = arena.clone();
+
+    *arena.get_mut(idx).unwrap() = 2;
+    let snap2 = arena.clone();
+
+    assert_eq!(snap0.len(), 0);
+    assert_eq!(snap1[idx], 1);
+    assert_eq!(snap2[idx], 2);
+
+    arena.remove(idx);
+    assert!(arena.get(idx).is_none());
+    assert_eq!(snap1[idx], 1);
+    assert_eq!(snap2[idx], 2);
+}
+
+#[test]
+fn snapshots_survive_multiple_modifications() {
+    let mut arena = Arena::new();
+    let first = arena.insert(10);
+    let snap_insert = arena.clone();
+
+    *arena.get_mut(first).unwrap() = 11;
+    let snap_update = arena.clone();
+
+    arena.remove(first);
+    let snap_remove = arena.clone();
+
+    assert_eq!(snap_insert[first], 10);
+    assert_eq!(snap_update[first], 11);
+    assert!(snap_remove.get(first).is_none());
+}

--- a/tests/nano_arena_tests.rs
+++ b/tests/nano_arena_tests.rs
@@ -63,32 +63,7 @@ fn get_mut() {
     assert_eq!(arena[idx], 6);
 }
 
-#[test]
-fn get2_mut() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    let idx2 = arena.insert(1);
-    {
-        let (item1, item2) = arena.get2_mut(idx1, idx2);
-        assert_eq!(item1, Some(&mut 0));
-        assert_eq!(item2, Some(&mut 1));
-        *item1.unwrap() = 3;
-        *item2.unwrap() = 4;
-    }
-    assert_eq!(arena[idx1], 3);
-    assert_eq!(arena[idx2], 4);
-}
-
-#[test]
-fn get2_mut_with_same_index_but_different_generation() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    arena.remove(idx1);
-    let idx2 = arena.insert(1);
-    let (item1, item2) = arena.get2_mut(idx1, idx2);
-    assert_eq!(item1, None);
-    assert_eq!(item2, Some(&mut 1));
-}
+// get2_mut tests are disabled; see standard_arena_tests for details.
 
 #[test]
 fn into_iter() {
@@ -130,16 +105,16 @@ fn out_of_bounds_remove_with_index_from_other_arena() {
     assert!(arena2.remove(idx).is_none());
 }
 
-#[test]
-fn out_of_bounds_get2_mut_with_index_from_other_arena() {
-    let mut arena1 = Arena::with_capacity(1);
-    let mut arena2 = Arena::with_capacity(2);
-    let idx1 = arena1.insert(42);
-    arena2.insert(0);
-    let idx2 = arena2.insert(0);
-
-    assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
-}
+// #[test]
+// fn out_of_bounds_get2_mut_with_index_from_other_arena() {
+//     let mut arena1 = Arena::with_capacity(1);
+//     let mut arena2 = Arena::with_capacity(2);
+//     let idx1 = arena1.insert(42);
+//     arena2.insert(0);
+//     let idx2 = arena2.insert(0);
+//
+//     assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
+// }
 
 #[test]
 fn drain() {

--- a/tests/pointer_slab_tests.rs
+++ b/tests/pointer_slab_tests.rs
@@ -32,21 +32,7 @@ fn get_mut() {
     assert_eq!(slab[idx], 6);
 }
 
-#[test]
-fn get2_mut() {
-    let mut slab = Slab::with_capacity(2);
-    let idx1 = slab.insert(0);
-    let idx2 = slab.insert(1);
-    {
-        let (item1, item2) = slab.get2_mut(idx1, idx2);
-        assert_eq!(item1, Some(&mut 0));
-        assert_eq!(item2, Some(&mut 1));
-        *item1.unwrap() = 3;
-        *item2.unwrap() = 4;
-    }
-    assert_eq!(slab[idx1], 3);
-    assert_eq!(slab[idx2], 4);
-}
+// get2_mut tests are disabled; see standard_arena_tests for details.
 
 #[test]
 fn into_iter() {
@@ -72,16 +58,16 @@ fn out_of_bounds_get_with_index_from_other_slab() {
 }
 
 
-#[test]
-fn out_of_bounds_get2_mut_with_index_from_other_slab() {
-    let mut slab1 = Slab::with_capacity(1);
-    let mut slab2 = Slab::with_capacity(2);
-    let idx1 = slab1.insert(42);
-    slab2.insert(0);
-    let idx2 = slab2.insert(0);
-
-    assert_eq!(slab1.get2_mut(idx1, idx2), (Some(&mut 42), None));
-}
+// #[test]
+// fn out_of_bounds_get2_mut_with_index_from_other_slab() {
+//     let mut slab1 = Slab::with_capacity(1);
+//     let mut slab2 = Slab::with_capacity(2);
+//     let idx1 = slab1.insert(42);
+//     slab2.insert(0);
+//     let idx2 = slab2.insert(0);
+//
+//     assert_eq!(slab1.get2_mut(idx1, idx2), (Some(&mut 42), None));
+// }
 
 #[test]
 fn drain() {

--- a/tests/small_arena_tests.rs
+++ b/tests/small_arena_tests.rs
@@ -62,32 +62,7 @@ fn get_mut() {
     assert_eq!(arena[idx], 6);
 }
 
-#[test]
-fn get2_mut() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    let idx2 = arena.insert(1);
-    {
-        let (item1, item2) = arena.get2_mut(idx1, idx2);
-        assert_eq!(item1, Some(&mut 0));
-        assert_eq!(item2, Some(&mut 1));
-        *item1.unwrap() = 3;
-        *item2.unwrap() = 4;
-    }
-    assert_eq!(arena[idx1], 3);
-    assert_eq!(arena[idx2], 4);
-}
-
-#[test]
-fn get2_mut_with_same_index_but_different_generation() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    arena.remove(idx1);
-    let idx2 = arena.insert(1);
-    let (item1, item2) = arena.get2_mut(idx1, idx2);
-    assert_eq!(item1, None);
-    assert_eq!(item2, Some(&mut 1));
-}
+// get2_mut tests are disabled; see standard_arena_tests for details.
 
 #[test]
 fn into_iter() {
@@ -129,16 +104,16 @@ fn out_of_bounds_remove_with_index_from_other_arena() {
     assert!(arena2.remove(idx).is_none());
 }
 
-#[test]
-fn out_of_bounds_get2_mut_with_index_from_other_arena() {
-    let mut arena1 = Arena::with_capacity(1);
-    let mut arena2 = Arena::with_capacity(2);
-    let idx1 = arena1.insert(42);
-    arena2.insert(0);
-    let idx2 = arena2.insert(0);
-
-    assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
-}
+// #[test]
+// fn out_of_bounds_get2_mut_with_index_from_other_arena() {
+//     let mut arena1 = Arena::with_capacity(1);
+//     let mut arena2 = Arena::with_capacity(2);
+//     let idx1 = arena1.insert(42);
+//     arena2.insert(0);
+//     let idx2 = arena2.insert(0);
+//
+//     assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
+// }
 
 #[test]
 fn drain() {

--- a/tests/standard_arena_tests.rs
+++ b/tests/standard_arena_tests.rs
@@ -62,32 +62,8 @@ fn get_mut() {
     assert_eq!(arena[idx], 6);
 }
 
-#[test]
-fn get2_mut() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    let idx2 = arena.insert(1);
-    {
-        let (item1, item2) = arena.get2_mut(idx1, idx2);
-        assert_eq!(item1, Some(&mut 0));
-        assert_eq!(item2, Some(&mut 1));
-        *item1.unwrap() = 3;
-        *item2.unwrap() = 4;
-    }
-    assert_eq!(arena[idx1], 3);
-    assert_eq!(arena[idx2], 4);
-}
-
-#[test]
-fn get2_mut_with_same_index_but_different_generation() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    arena.remove(idx1);
-    let idx2 = arena.insert(1);
-    let (item1, item2) = arena.get2_mut(idx1, idx2);
-    assert_eq!(item1, None);
-    assert_eq!(item2, Some(&mut 1));
-}
+// get2_mut tests are disabled because the method relies on `Vec::split_at_mut`,
+// which cannot be implemented safely with `im::Vector` storage.
 
 #[test]
 fn into_iter() {
@@ -129,16 +105,16 @@ fn out_of_bounds_remove_with_index_from_other_arena() {
     assert!(arena2.remove(idx).is_none());
 }
 
-#[test]
-fn out_of_bounds_get2_mut_with_index_from_other_arena() {
-    let mut arena1 = Arena::with_capacity(1);
-    let mut arena2 = Arena::with_capacity(2);
-    let idx1 = arena1.insert(42);
-    arena2.insert(0);
-    let idx2 = arena2.insert(0);
-
-    assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
-}
+// #[test]
+// fn out_of_bounds_get2_mut_with_index_from_other_arena() {
+//     let mut arena1 = Arena::with_capacity(1);
+//     let mut arena2 = Arena::with_capacity(2);
+//     let idx1 = arena1.insert(42);
+//     arena2.insert(0);
+//     let idx2 = arena2.insert(0);
+//
+//     assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
+// }
 
 #[test]
 fn drain() {

--- a/tests/standard_slab_tests.rs
+++ b/tests/standard_slab_tests.rs
@@ -32,21 +32,7 @@ fn get_mut() {
     assert_eq!(slab[idx], 6);
 }
 
-#[test]
-fn get2_mut() {
-    let mut slab = Slab::with_capacity(2);
-    let idx1 = slab.insert(0);
-    let idx2 = slab.insert(1);
-    {
-        let (item1, item2) = slab.get2_mut(idx1, idx2);
-        assert_eq!(item1, Some(&mut 0));
-        assert_eq!(item2, Some(&mut 1));
-        *item1.unwrap() = 3;
-        *item2.unwrap() = 4;
-    }
-    assert_eq!(slab[idx1], 3);
-    assert_eq!(slab[idx2], 4);
-}
+// get2_mut tests are disabled; see standard_arena_tests for details.
 
 #[test]
 fn into_iter() {
@@ -72,16 +58,16 @@ fn out_of_bounds_get_with_index_from_other_slab() {
 }
 
 
-#[test]
-fn out_of_bounds_get2_mut_with_index_from_other_slab() {
-    let mut slab1 = Slab::with_capacity(1);
-    let mut slab2 = Slab::with_capacity(2);
-    let idx1 = slab1.insert(42);
-    slab2.insert(0);
-    let idx2 = slab2.insert(0);
-
-    assert_eq!(slab1.get2_mut(idx1, idx2), (Some(&mut 42), None));
-}
+// #[test]
+// fn out_of_bounds_get2_mut_with_index_from_other_slab() {
+//     let mut slab1 = Slab::with_capacity(1);
+//     let mut slab2 = Slab::with_capacity(2);
+//     let idx1 = slab1.insert(42);
+//     slab2.insert(0);
+//     let idx2 = slab2.insert(0);
+//
+//     assert_eq!(slab1.get2_mut(idx1, idx2), (Some(&mut 42), None));
+// }
 
 #[test]
 fn drain() {

--- a/tests/tiny_arena_tests.rs
+++ b/tests/tiny_arena_tests.rs
@@ -62,32 +62,7 @@ fn get_mut() {
     assert_eq!(arena[idx], 6);
 }
 
-#[test]
-fn get2_mut() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    let idx2 = arena.insert(1);
-    {
-        let (item1, item2) = arena.get2_mut(idx1, idx2);
-        assert_eq!(item1, Some(&mut 0));
-        assert_eq!(item2, Some(&mut 1));
-        *item1.unwrap() = 3;
-        *item2.unwrap() = 4;
-    }
-    assert_eq!(arena[idx1], 3);
-    assert_eq!(arena[idx2], 4);
-}
-
-#[test]
-fn get2_mut_with_same_index_but_different_generation() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    arena.remove(idx1);
-    let idx2 = arena.insert(1);
-    let (item1, item2) = arena.get2_mut(idx1, idx2);
-    assert_eq!(item1, None);
-    assert_eq!(item2, Some(&mut 1));
-}
+// get2_mut tests are disabled; see standard_arena_tests for details.
 
 #[test]
 fn into_iter() {
@@ -129,16 +104,16 @@ fn out_of_bounds_remove_with_index_from_other_arena() {
     assert!(arena2.remove(idx).is_none());
 }
 
-#[test]
-fn out_of_bounds_get2_mut_with_index_from_other_arena() {
-    let mut arena1 = Arena::with_capacity(1);
-    let mut arena2 = Arena::with_capacity(2);
-    let idx1 = arena1.insert(42);
-    arena2.insert(0);
-    let idx2 = arena2.insert(0);
-
-    assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
-}
+// #[test]
+// fn out_of_bounds_get2_mut_with_index_from_other_arena() {
+//     let mut arena1 = Arena::with_capacity(1);
+//     let mut arena2 = Arena::with_capacity(2);
+//     let idx1 = arena1.insert(42);
+//     arena2.insert(0);
+//     let idx2 = arena2.insert(0);
+//
+//     assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
+// }
 
 #[test]
 fn drain() {

--- a/tests/tiny_wrap_arena_tests.rs
+++ b/tests/tiny_wrap_arena_tests.rs
@@ -62,32 +62,7 @@ fn get_mut() {
     assert_eq!(arena[idx], 6);
 }
 
-#[test]
-fn get2_mut() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    let idx2 = arena.insert(1);
-    {
-        let (item1, item2) = arena.get2_mut(idx1, idx2);
-        assert_eq!(item1, Some(&mut 0));
-        assert_eq!(item2, Some(&mut 1));
-        *item1.unwrap() = 3;
-        *item2.unwrap() = 4;
-    }
-    assert_eq!(arena[idx1], 3);
-    assert_eq!(arena[idx2], 4);
-}
-
-#[test]
-fn get2_mut_with_same_index_but_different_generation() {
-    let mut arena = Arena::with_capacity(2);
-    let idx1 = arena.insert(0);
-    arena.remove(idx1);
-    let idx2 = arena.insert(1);
-    let (item1, item2) = arena.get2_mut(idx1, idx2);
-    assert_eq!(item1, None);
-    assert_eq!(item2, Some(&mut 1));
-}
+// get2_mut tests are disabled; see standard_arena_tests for details.
 
 #[test]
 fn into_iter() {
@@ -129,16 +104,16 @@ fn out_of_bounds_remove_with_index_from_other_arena() {
     assert!(arena2.remove(idx).is_none());
 }
 
-#[test]
-fn out_of_bounds_get2_mut_with_index_from_other_arena() {
-    let mut arena1 = Arena::with_capacity(1);
-    let mut arena2 = Arena::with_capacity(2);
-    let idx1 = arena1.insert(42);
-    arena2.insert(0);
-    let idx2 = arena2.insert(0);
-
-    assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
-}
+// #[test]
+// fn out_of_bounds_get2_mut_with_index_from_other_arena() {
+//     let mut arena1 = Arena::with_capacity(1);
+//     let mut arena2 = Arena::with_capacity(2);
+//     let idx1 = arena1.insert(42);
+//     arena2.insert(0);
+//     let idx2 = arena2.insert(0);
+//
+//     assert_eq!(arena1.get2_mut(idx1, idx2), (Some(&mut 42), None));
+// }
 
 #[test]
 fn drain() {


### PR DESCRIPTION
## Summary
- switch internal arena storage to `im::Vector`
- remove `get2_mut` API which can't work safely with `im::Vector`
- update iterators and drain logic for the new storage
- add clone immutability tests
- adjust existing tests for removed method

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684c77dd920c8323a884465237d807f0