### PR TITLE
Add retain/drain clone immutability test

### DIFF
--- a/tests/clone_immutability.rs
+++ b/tests/clone_immutability.rs
@@ -38,3 +38,30 @@ fn snapshots_survive_multiple_modifications() {
     assert_eq!(snap_update[first], 11);
     assert!(snap_remove.get(first).is_none());
 }
+#[test]
+fn snapshots_after_retain_and_drain() {
+    let mut arena = Arena::new();
+    let a = arena.insert(1);
+    let b = arena.insert(2);
+    let c = arena.insert(3);
+
+    let snap_full = arena.clone();
+
+    arena.retain(|_, v| *v % 2 == 0);
+    let snap_retained = arena.clone();
+
+    for _ in arena.drain() {}
+
+    assert_eq!(snap_full[a], 1);
+    assert_eq!(snap_full[b], 2);
+    assert_eq!(snap_full[c], 3);
+
+    assert!(snap_retained.get(a).is_none());
+    assert_eq!(snap_retained[b], 2);
+    assert!(snap_retained.get(c).is_none());
+
+    assert_eq!(arena.len(), 0);
+    assert!(arena.get(a).is_none());
+    assert!(arena.get(b).is_none());
+    assert!(arena.get(c).is_none());
+}

--- a/tests/nano_arena_tests.rs
+++ b/tests/nano_arena_tests.rs
@@ -157,3 +157,20 @@ fn clear() {
     assert_eq!(arena.capacity(), 4);
     assert_eq!(arena.len(), 0);
 }
+
+#[test]
+fn retain() {
+    let mut arena = Arena::new();
+    let a = arena.insert(1);
+    let b = arena.insert(2);
+    let c = arena.insert(3);
+
+    arena.retain(|_, v| *v % 2 == 1);
+
+    assert!(arena.contains(a));
+    assert!(arena.get(b).is_none());
+    assert!(arena.contains(c));
+    assert_eq!(arena[a], 1);
+    assert_eq!(arena[c], 3);
+    assert_eq!(arena.len(), 2);
+}

--- a/tests/small_arena_tests.rs
+++ b/tests/small_arena_tests.rs
@@ -156,3 +156,20 @@ fn clear() {
     assert_eq!(arena.capacity(), 4);
     assert_eq!(arena.len(), 0);
 }
+
+#[test]
+fn retain() {
+    let mut arena = Arena::new();
+    let a = arena.insert(1);
+    let b = arena.insert(2);
+    let c = arena.insert(3);
+
+    arena.retain(|_, v| *v % 2 == 1);
+
+    assert!(arena.contains(a));
+    assert!(arena.get(b).is_none());
+    assert!(arena.contains(c));
+    assert_eq!(arena[a], 1);
+    assert_eq!(arena[c], 3);
+    assert_eq!(arena.len(), 2);
+}

--- a/tests/standard_arena_tests.rs
+++ b/tests/standard_arena_tests.rs
@@ -157,3 +157,20 @@ fn clear() {
     assert_eq!(arena.capacity(), 4);
     assert_eq!(arena.len(), 0);
 }
+
+#[test]
+fn retain() {
+    let mut arena = Arena::new();
+    let a = arena.insert(1);
+    let b = arena.insert(2);
+    let c = arena.insert(3);
+
+    arena.retain(|_, v| *v % 2 == 1);
+
+    assert!(arena.contains(a));
+    assert!(arena.get(b).is_none());
+    assert!(arena.contains(c));
+    assert_eq!(arena[a], 1);
+    assert_eq!(arena[c], 3);
+    assert_eq!(arena.len(), 2);
+}

--- a/tests/tiny_arena_tests.rs
+++ b/tests/tiny_arena_tests.rs
@@ -156,3 +156,20 @@ fn clear() {
     assert_eq!(arena.capacity(), 4);
     assert_eq!(arena.len(), 0);
 }
+
+#[test]
+fn retain() {
+    let mut arena = Arena::new();
+    let a = arena.insert(1);
+    let b = arena.insert(2);
+    let c = arena.insert(3);
+
+    arena.retain(|_, v| *v % 2 == 1);
+
+    assert!(arena.contains(a));
+    assert!(arena.get(b).is_none());
+    assert!(arena.contains(c));
+    assert_eq!(arena[a], 1);
+    assert_eq!(arena[c], 3);
+    assert_eq!(arena.len(), 2);
+}

--- a/tests/tiny_wrap_arena_tests.rs
+++ b/tests/tiny_wrap_arena_tests.rs
@@ -156,3 +156,20 @@ fn clear() {
     assert_eq!(arena.capacity(), 4);
     assert_eq!(arena.len(), 0);
 }
+
+#[test]
+fn retain() {
+    let mut arena = Arena::new();
+    let a = arena.insert(1);
+    let b = arena.insert(2);
+    let c = arena.insert(3);
+
+    arena.retain(|_, v| *v % 2 == 1);
+
+    assert!(arena.contains(a));
+    assert!(arena.get(b).is_none());
+    assert!(arena.contains(c));
+    assert_eq!(arena[a], 1);
+    assert_eq!(arena[c], 3);
+    assert_eq!(arena.len(), 2);
+}


### PR DESCRIPTION
## Summary
- add `snapshots_after_retain_and_drain` to verify clone stability after retaining and draining

## Testing
- `cargo test snapshots_after_retain_and_drain -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684ca571b42c8323883253a64de62061