### PR TITLE
Document snapshot behavior

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-README.md -diff -merge

--- a/README.md
+++ b/README.md
@@ -6,3 +6,20 @@ indices. Forked from https://gitlab.com/tekne/typed-generational-arena.
 
 Immutable via Im.
 
+## Snapshot immutability
+
+Cloning an arena is cheap and returns an immutable snapshot. Mutating the
+original arena afterwards does not change existing snapshots.
+
+```rust
+use typed_generational_arena::StandardArena;
+
+let mut arena = StandardArena::new();
+let idx = arena.insert(1);
+let snapshot = arena.clone();
+
+*arena.get_mut(idx).unwrap() = 2;
+
+assert_eq!(snapshot[idx], 1);
+```
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,23 @@ for (idx, value) in &arena {
 }
 ```
 
+### Snapshot immutability
+
+Cloning an arena is an `O(1)` operation that returns an immutable snapshot.
+Further mutations to the original arena do not affect snapshots.
+
+```rust
+use typed_generational_arena::StandardArena;
+
+let mut arena = StandardArena::new();
+let idx = arena.insert(1);
+let snapshot = arena.clone();
+
+*arena.get_mut(idx).unwrap() = 2;
+
+assert_eq!(snapshot[idx], 1);
+```
+
 ## `no_std`
 
 To enable `no_std` compatibility, disable the on-by-default "std" feature. This


### PR DESCRIPTION
## Summary
- allow diffing of README by deleting `.gitattributes`
- document snapshot immutability in the README
- add doctest showing clones remain immutable after changes

## Testing
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684cadcc32fc83238e3bff4ecde02a69