### PR TITLE
Enable parallel iteration with rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "bitmaps",
  "rand_core",
  "rand_xoshiro",
+ "rayon",
  "sized-chunks",
  "typenum",
  "version_check",
@@ -529,6 +530,7 @@ dependencies = [
  "nonzero_ext",
  "num-traits",
  "quickcheck",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ cfg-if = "1.0"
 num-traits = { version = "0.2", default-features = false }
 nonzero_ext = "0.3"
 im = "15.1.0"
+rayon = { version = "1.10", optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0"
@@ -30,6 +31,7 @@ harness = false
 [features]
 default = ["std"]
 std = ["num-traits/std"]
+rayon = ["im/rayon", "dep:rayon"]
 
 [profile.bench]
 debug = true

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -964,3 +964,159 @@ impl<T: Clone, I: ArenaIndex, G: FixedGenerationalIndex> ops::IndexMut<Index<T, 
         self.get_mut(index).expect("No element at index")
     }
 }
+
+#[cfg(feature = "rayon")]
+pub mod rayon_support {
+    use super::*;
+    use rayon::iter::{
+        IntoParallelRefIterator,
+        IntoParallelRefMutIterator,
+        IndexedParallelIterator,
+        ParallelIterator,
+    };
+    use im::vector::rayon::{ParIter as ImParIter, ParIterMut as ImParIterMut};
+
+    fn entry_to_ref<'a, T: Clone, I: ArenaIndex, G: FixedGenerationalIndex>(
+        (index, entry): (usize, &'a Entry<T, I, G>),
+    ) -> Option<(Index<T, I, G>, &'a T)> {
+        match entry {
+            Entry::Occupied { generation, value } => {
+                Some((Index::new(I::from_idx(index), *generation), value))
+            }
+            _ => None,
+        }
+    }
+
+    fn entry_to_mut<'a, T: Clone, I: ArenaIndex, G: FixedGenerationalIndex>(
+        (index, entry): (usize, &'a mut Entry<T, I, G>),
+    ) -> Option<(Index<T, I, G>, &'a mut T)> {
+        match entry {
+            Entry::Occupied { generation, value } => {
+                Some((Index::new(I::from_idx(index), *generation), value))
+            }
+            _ => None,
+        }
+    }
+
+    /// Parallel iterator over shared references to arena elements.
+    pub struct ParIter<'a, T, I, G>
+    where
+        T: Clone + Send + Sync + 'a,
+        I: ArenaIndex + Send + Sync + 'a,
+        G: FixedGenerationalIndex + Send + Sync + 'a,
+    {
+        inner: rayon::iter::FilterMap<
+            rayon::iter::Enumerate<ImParIter<'a, Entry<T, I, G>>>,
+            fn((usize, &'a Entry<T, I, G>)) -> Option<(Index<T, I, G>, &'a T)>,
+        >,
+    }
+
+
+    /// Parallel iterator over mutable references to arena elements.
+    pub struct ParIterMut<'a, T, I, G>
+    where
+        T: Clone + Send + Sync + 'a,
+        I: ArenaIndex + Send + Sync + 'a,
+        G: FixedGenerationalIndex + Send + Sync + 'a,
+    {
+        inner: rayon::iter::FilterMap<
+            rayon::iter::Enumerate<ImParIterMut<'a, Entry<T, I, G>>>,
+            fn((usize, &'a mut Entry<T, I, G>)) -> Option<(Index<T, I, G>, &'a mut T)>,
+        >,
+    }
+
+
+    impl<'a, T, I, G> core::fmt::Debug for ParIter<'a, T, I, G>
+    where
+        T: Clone + Send + Sync + 'a,
+        I: ArenaIndex + Send + Sync + 'a,
+        G: FixedGenerationalIndex + Send + Sync + 'a,
+    {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("ParIter").finish()
+        }
+    }
+
+    impl<'a, T, I, G> core::fmt::Debug for ParIterMut<'a, T, I, G>
+    where
+        T: Clone + Send + Sync + 'a,
+        I: ArenaIndex + Send + Sync + 'a,
+        G: FixedGenerationalIndex + Send + Sync + 'a,
+    {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("ParIterMut").finish()
+        }
+    }
+
+    impl<'a, T, I, G> ParallelIterator for ParIter<'a, T, I, G>
+    where
+        T: Clone + Send + Sync + 'a,
+        I: ArenaIndex + Send + Sync + 'a,
+        G: FixedGenerationalIndex + Send + Sync + 'a,
+    {
+        type Item = (Index<T, I, G>, &'a T);
+
+        fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where
+            C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+        {
+            self.inner.drive_unindexed(consumer)
+        }
+    }
+
+    impl<'a, T, I, G> ParallelIterator for ParIterMut<'a, T, I, G>
+    where
+        T: Clone + Send + Sync + 'a,
+        I: ArenaIndex + Send + Sync + 'a,
+        G: FixedGenerationalIndex + Send + Sync + 'a,
+    {
+        type Item = (Index<T, I, G>, &'a mut T);
+
+        fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where
+            C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+        {
+            self.inner.drive_unindexed(consumer)
+        }
+    }
+
+    impl<'a, T, I, G> IntoParallelRefIterator<'a> for Arena<T, I, G>
+    where
+        T: Clone + Send + Sync + 'a,
+        I: ArenaIndex + Send + Sync + 'a,
+        G: FixedGenerationalIndex + Send + Sync + 'a,
+    {
+        type Item = (Index<T, I, G>, &'a T);
+        type Iter = ParIter<'a, T, I, G>;
+
+        fn par_iter(&'a self) -> <Self as IntoParallelRefIterator<'a>>::Iter {
+            ParIter {
+                inner: self
+                    .items
+                    .par_iter()
+                    .enumerate()
+                    .filter_map(entry_to_ref::<T, I, G>),
+            }
+        }
+    }
+
+    impl<'a, T, I, G> IntoParallelRefMutIterator<'a> for Arena<T, I, G>
+    where
+        T: Clone + Send + Sync + 'a,
+        I: ArenaIndex + Send + Sync + 'a,
+        G: FixedGenerationalIndex + Send + Sync + 'a,
+    {
+        type Item = (Index<T, I, G>, &'a mut T);
+        type Iter = ParIterMut<'a, T, I, G>;
+
+        fn par_iter_mut(&'a mut self) -> <Self as IntoParallelRefMutIterator<'a>>::Iter {
+            ParIterMut {
+                inner: self
+                    .items
+                    .par_iter_mut()
+                    .enumerate()
+                    .filter_map(entry_to_mut::<T, I, G>),
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,8 @@ extern crate num_traits;
 #[macro_use]
 extern crate cfg_if;
 extern crate im;
+#[cfg(feature = "rayon")]
+extern crate rayon;
 
 cfg_if! {
     if #[cfg(feature = "std")] {

--- a/tests/parallel_tests.rs
+++ b/tests/parallel_tests.rs
@@ -1,0 +1,29 @@
+extern crate typed_generational_arena;
+extern crate rayon;
+use typed_generational_arena::StandardArena as Arena;
+use rayon::iter::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator};
+
+#[test]
+fn par_iter_matches_sequential() {
+    let mut arena = Arena::new();
+    for i in 0..100 {
+        arena.insert(i);
+    }
+    let mut seq: Vec<_> = arena.iter().map(|(_, v)| *v).collect();
+    let mut par: Vec<_> = (&arena).par_iter().map(|(_, v)| *v).collect();
+    seq.sort();
+    par.sort();
+    assert_eq!(seq, par);
+}
+
+#[test]
+fn par_iter_mut_updates() {
+    let mut arena = Arena::new();
+    for i in 0..100 {
+        arena.insert(i);
+    }
+    (&mut arena).par_iter_mut().for_each(|(_, v)| *v *= 2);
+    let mut values: Vec<_> = arena.iter().map(|(_, v)| *v).collect();
+    values.sort();
+    assert_eq!(values, (0..100).map(|x| x * 2).collect::<Vec<_>>());
+}

--- a/tests/parallel_tests.rs
+++ b/tests/parallel_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rayon")]
+
 extern crate typed_generational_arena;
 extern crate rayon;
 use typed_generational_arena::StandardArena as Arena;


### PR DESCRIPTION
## Summary
- add optional rayon dependency and feature
- implement parallel iterators in the arena when rayon is enabled
- test that par_iter and par_iter_mut work

## Testing
- `cargo test --features rayon`

------
https://chatgpt.com/codex/tasks/task_e_684cbd30df788323a921e9985fbb9ae3