### PR TITLE
Annotate selected tests with intent comments

### DIFF
--- a/tests/clone_generation_wrap.rs
+++ b/tests/clone_generation_wrap.rs
@@ -2,6 +2,7 @@ extern crate typed_generational_arena;
 
 use typed_generational_arena::{TinyWrapArena, TinyWrapIndex};
 
+// Clone the arena repeatedly while inserting and removing elements until generations wrap, ensuring each snapshot retains the expected data.
 #[test]
 fn clone_insert_remove_until_wrap() {
     const WRAP_LIMIT: usize = (std::u16::MAX as usize) + 10;

--- a/tests/clone_immutability.rs
+++ b/tests/clone_immutability.rs
@@ -1,6 +1,7 @@
 extern crate typed_generational_arena;
 use typed_generational_arena::StandardArena as Arena;
 
+// Cloning should freeze a snapshot so later modifications do not affect it.
 #[test]
 fn snapshots_are_immutable_after_clone() {
     let mut arena = Arena::new();
@@ -21,6 +22,7 @@ fn snapshots_are_immutable_after_clone() {
     assert_eq!(snap1[idx], 1);
     assert_eq!(snap2[idx], 2);
 }
+// Snapshots should remain consistent through multiple arena changes.
 
 #[test]
 fn snapshots_survive_multiple_modifications() {
@@ -38,6 +40,7 @@ fn snapshots_survive_multiple_modifications() {
     assert_eq!(snap_update[first], 11);
     assert!(snap_remove.get(first).is_none());
 }
+// Verify snapshots remain valid after retain and drain operations.
 #[test]
 fn snapshots_after_retain_and_drain() {
     let mut arena = Arena::new();

--- a/tests/clone_independence.rs
+++ b/tests/clone_independence.rs
@@ -1,6 +1,7 @@
 extern crate typed_generational_arena;
 use typed_generational_arena::StandardArena as Arena;
 
+// Ensure that mutations to a cloned arena do not affect the original and vice versa.
 #[test]
 fn cloned_arenas_are_independent() {
     let mut arena = Arena::new();

--- a/tests/clone_quickchecks.rs
+++ b/tests/clone_quickchecks.rs
@@ -38,6 +38,7 @@ struct Snapshot {
     live: Vec<(Index<usize>, usize)>,
     later: Vec<(Index<usize>, usize)>, // indices and values inserted after this snapshot
 }
+// Property: cloned snapshots must preserve and ignore future operations on the original arena.
 
 quickcheck! {
     fn snapshots_survive_ops(ops: Vec<Op>) -> bool {

--- a/tests/clone_snapshot_stress.rs
+++ b/tests/clone_snapshot_stress.rs
@@ -2,6 +2,7 @@ extern crate typed_generational_arena;
 
 use typed_generational_arena::{NanoArena, SmallArena, StandardArena, TinyArena, TinyWrapArena};
 
+// Macro to stress-test snapshot cloning for various arena types.
 macro_rules! snapshot_stress_test {
     ($name:ident, $arena_ty:ty) => {
         #[test]
@@ -57,8 +58,13 @@ macro_rules! snapshot_stress_test {
     };
 }
 
+// Stress test snapshot behavior in NanoArena
 snapshot_stress_test!(nano_snapshot_stress, NanoArena<usize>);
+// Stress test snapshot behavior in SmallArena
 snapshot_stress_test!(small_snapshot_stress, SmallArena<usize>);
+// Stress test snapshot behavior in StandardArena
 snapshot_stress_test!(standard_snapshot_stress, StandardArena<usize>);
+// Stress test snapshot behavior in TinyArena
 snapshot_stress_test!(tiny_snapshot_stress, TinyArena<usize>);
+// Stress test snapshot behavior in TinyWrapArena
 snapshot_stress_test!(tinywrap_snapshot_stress, TinyWrapArena<usize>);

--- a/tests/nano_arena_quickchecks.rs
+++ b/tests/nano_arena_quickchecks.rs
@@ -6,6 +6,7 @@ use typed_generational_arena::NanoArena as Arena;
 use std::collections::BTreeSet;
 use std::iter::FromIterator;
 
+// Property: inserted elements remain accessible.
 quickcheck! {
     fn always_contains_inserted_elements(elems: Vec<usize>) -> bool {
         let mut arena = Arena::new();
@@ -16,6 +17,7 @@ quickcheck! {
         indices.into_iter().all(|i| arena.contains(i))
     }
 }
+// Property: removed elements are no longer accessible.
 
 quickcheck! {
     fn never_contains_deleted_elements(elems: Vec<usize>) -> bool {
@@ -29,6 +31,7 @@ quickcheck! {
         }
         indices.into_iter().all(|i| !arena.contains(i))
     }
+// Property: re-inserting after deletion yields fresh indices.
 }
 
 quickcheck! {
@@ -49,6 +52,7 @@ quickcheck! {
         new_indices.into_iter().enumerate().all(|(i, idx)| {
             !arena.contains(indices[i]) && arena.remove(idx).unwrap() == elems[i]
         })
+// Property: operations maintain consistent state.
     }
 }
 
@@ -88,6 +92,7 @@ quickcheck! {
         for rem in remaining {
             let i = live_indices.iter().position(|&(_, v)| v == rem).unwrap();
             live_indices.remove(i);
+// Property: iterator reports all elements.
         }
     }
 }
@@ -96,6 +101,7 @@ quickcheck! {
     fn iter(elems: BTreeSet<usize>) -> bool {
         let arena = Arena::from_iter(elems.iter().take(std::u8::MAX as usize).cloned());
         arena.iter().all(|(idx, value)| {
+// Property: iter_mut can modify all elements.
             elems.contains(value) && arena.get(idx) == Some(value)
         })
     }
@@ -108,6 +114,7 @@ quickcheck! {
             *value = value.wrapping_add(1);
         }
         arena.iter().all(|(idx, value)| {
+// Property: from_iter then into_iter preserves the set.
             let orig_value = value.wrapping_sub(1);
             elems.contains(&orig_value) && arena.get(idx) == Some(value)
         })


### PR DESCRIPTION
## Summary
- document snapshot behavior tests
- describe property-based tests for clone logic
- note purpose of snapshot stress tests
- clarify quickcheck behaviors

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684da2625e808323aa4f2f6a1cf1c4cb