### PR TITLE
Add comprehensive parallel iterator tests

### DIFF
--- a/tests/parallel_combinator_tests.rs
+++ b/tests/parallel_combinator_tests.rs
@@ -22,52 +22,53 @@ macro_rules! arena_parallel_tests {
 
             #[test]
             fn par_iter_combinators() {
-                let arena = init_arena();
-                let seq_zip: Vec<_> = arena
+                let arena_a = init_arena();
+                let arena_b = init_arena();
+
+                let seq_zip: Vec<_> = arena_a
                     .iter()
                     .map(|(_, v)| *v)
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                    .zip(0..N)
-                    .map(|(v, i)| v + i)
+                    .zip(arena_b.iter().map(|(_, v)| *v))
+                    .map(|(a, b)| a + b)
                     .collect();
-                let par_zip: Vec<_> = arena
-                    .par_iter()
-                    .map(|(_, v)| *v)
-                    .collect::<Vec<_>>()
+
+                let left: Vec<_> = arena_a.par_iter().map(|(_, v)| *v).collect();
+                let right: Vec<_> = arena_b.par_iter().map(|(_, v)| *v).collect();
+                let par_zip: Vec<_> = left
                     .into_par_iter()
-                    .zip((0..N).into_par_iter())
-                    .map(|(v, i)| v + i)
+                    .zip(right.into_par_iter())
+                    .map(|(a, b)| a + b)
                     .collect();
+
                 assert_eq!(seq_zip, par_zip);
 
-                let seq_filter: Vec<_> = arena
+                let seq_filter: Vec<_> = arena_a
                     .iter()
                     .filter(|item| *(item.1) % 2 == 0)
                     .map(|item| *(item.1))
                     .collect();
-                let par_filter: Vec<_> = arena
+                let par_filter: Vec<_> = arena_a
                     .par_iter()
                     .filter(|item| *(item.1) % 2 == 0)
                     .map(|item| *(item.1))
                     .collect();
                 assert_eq!(seq_filter, par_filter);
 
-                let seq_flat_map: Vec<_> = arena
+                let seq_flat_map: Vec<_> = arena_a
                     .iter()
                     .flat_map(|(_, v)| vec![*v, *v + 1])
                     .collect();
-                let par_flat_map: Vec<_> = arena
+                let par_flat_map: Vec<_> = arena_a
                     .par_iter()
                     .flat_map(|(_, v)| vec![*v, *v + 1])
                     .collect();
                 assert_eq!(seq_flat_map, par_flat_map);
 
-                let nested_seq: Vec<Vec<_>> = arena
+                let nested_seq: Vec<Vec<_>> = arena_a
                     .iter()
                     .map(|(_, v)| vec![*v, *v + 1])
                     .collect();
-                let nested_par: Vec<Vec<_>> = arena
+                let nested_par: Vec<Vec<_>> = arena_a
                     .par_iter()
                     .map(|(_, v)| vec![*v, *v + 1])
                     .collect();
@@ -75,73 +76,83 @@ macro_rules! arena_parallel_tests {
                 let par_flatten: Vec<_> = nested_par.into_par_iter().flatten().collect();
                 assert_eq!(seq_flatten, par_flatten);
 
-                let seq_sum: usize = arena.iter().map(|(_, v)| *v).sum();
-                let par_sum: usize = arena
+                let seq_sum: usize = arena_a.iter().map(|(_, v)| *v).sum();
+                let par_sum: usize = arena_a
                     .par_iter()
                     .fold(|| 0, |acc, (_, v)| acc + *v)
                     .reduce(|| 0, |a, b| a + b);
                 assert_eq!(seq_sum, par_sum);
 
-                let seq_min = arena.iter().map(|(_, v)| *v).min();
-                let par_min = arena.par_iter().map(|(_, v)| *v).min();
+                let seq_min = arena_a.iter().map(|(_, v)| *v).min();
+                let par_min = arena_a.par_iter().map(|(_, v)| *v).min();
                 assert_eq!(seq_min, par_min);
 
-                let seq_max = arena.iter().map(|(_, v)| *v).max();
-                let par_max = arena.par_iter().map(|(_, v)| *v).max();
+                let seq_max = arena_a.iter().map(|(_, v)| *v).max();
+                let par_max = arena_a.par_iter().map(|(_, v)| *v).max();
                 assert_eq!(seq_max, par_max);
             }
 
             #[test]
             fn par_iter_mut_combinators() {
-                let mut arena = init_arena();
-                let mut values: Vec<_> = arena
-                    .par_iter_mut()
-                    .map(|(_, v)| v)
-                    .collect();
-                values
-                    .into_par_iter()
-                    .zip((0..N).into_par_iter())
-                    .for_each(|(v, i)| *v += i);
+                let mut arena_a = init_arena();
+                let arena_b = init_arena();
 
-                let seq_flat_map: Vec<_> = arena
+                let left: Vec<_> = arena_a.par_iter_mut().map(|(_, v)| v).collect();
+                let right: Vec<_> = arena_b.par_iter().map(|(_, v)| *v).collect();
+                left
+                    .into_par_iter()
+                    .zip(right.into_par_iter())
+                    .for_each(|(a, b)| *a += b);
+
+                let mut seq_arena_a = init_arena();
+                let seq_arena_b = init_arena();
+                for ((_, a), (_, b)) in seq_arena_a.iter_mut().zip(seq_arena_b.iter()) {
+                    *a += *b;
+                }
+
+                let par_result: Vec<_> = arena_a.iter().map(|(_, v)| *v).collect();
+                let seq_result: Vec<_> = seq_arena_a.iter().map(|(_, v)| *v).collect();
+                assert_eq!(par_result, seq_result);
+
+                let seq_flat_map: Vec<_> = arena_a
                     .iter()
                     .flat_map(|(_, v)| vec![*v, *v + 1])
                     .collect();
-                let par_flat_map: Vec<_> = arena
+                let par_flat_map: Vec<_> = arena_a
                     .par_iter_mut()
                     .flat_map(|(_, v)| vec![*v, *v + 1])
                     .collect();
                 assert_eq!(seq_flat_map, par_flat_map);
 
-                let seq_sum: usize = arena.iter().map(|(_, v)| *v).sum();
-                let par_sum: usize = arena
+                let seq_sum: usize = arena_a.iter().map(|(_, v)| *v).sum();
+                let par_sum: usize = arena_a
                     .par_iter_mut()
                     .fold(|| 0, |acc, (_, v)| acc + *v)
                     .reduce(|| 0, |a, b| a + b);
                 assert_eq!(seq_sum, par_sum);
 
-                let seq_filter: Vec<_> = arena
+                let seq_filter: Vec<_> = arena_a
                     .iter()
                     .filter(|item| *(item.1) % 2 == 0)
                     .map(|item| *(item.1))
                     .collect();
-                let par_filter: Vec<_> = arena
+                let par_filter: Vec<_> = arena_a
                     .par_iter_mut()
                     .filter(|item| *(item.1) % 2 == 0)
                     .map(|item| *(item.1))
                     .collect();
                 assert_eq!(seq_filter, par_filter);
 
-                let seq_min = arena.iter().map(|(_, v)| *v).min();
-                let par_min = arena.par_iter_mut().map(|(_, v)| *v).min();
+                let seq_min = arena_a.iter().map(|(_, v)| *v).min();
+                let par_min = arena_a.par_iter_mut().map(|(_, v)| *v).min();
                 assert_eq!(seq_min, par_min);
 
-                let seq_max = arena.iter().map(|(_, v)| *v).max();
-                let par_max = arena.par_iter_mut().map(|(_, v)| *v).max();
+                let seq_max = arena_a.iter().map(|(_, v)| *v).max();
+                let par_max = arena_a.par_iter_mut().map(|(_, v)| *v).max();
                 assert_eq!(seq_max, par_max);
 
-                let nested_seq: Vec<Vec<_>> = arena.iter().map(|(_, v)| vec![*v]).collect();
-                let nested_par: Vec<Vec<_>> = arena.par_iter_mut().map(|(_, v)| vec![*v]).collect();
+                let nested_seq: Vec<Vec<_>> = arena_a.iter().map(|(_, v)| vec![*v]).collect();
+                let nested_par: Vec<Vec<_>> = arena_a.par_iter_mut().map(|(_, v)| vec![*v]).collect();
                 let seq_flatten: Vec<_> = nested_seq.into_iter().flatten().collect();
                 let par_flatten: Vec<_> = nested_par.into_par_iter().flatten().collect();
                 assert_eq!(seq_flatten, par_flatten);

--- a/tests/parallel_combinator_tests.rs
+++ b/tests/parallel_combinator_tests.rs
@@ -1,0 +1,182 @@
+#![cfg(feature = "rayon")]
+
+extern crate generational_arena_im;
+extern crate rayon;
+
+use generational_arena_im::*;
+use rayon::prelude::*;
+
+macro_rules! arena_parallel_tests {
+    ($mod_name:ident, $arena_ty:ty) => {
+        mod $mod_name {
+            use super::*;
+            const N: usize = 64;
+
+            fn init_arena() -> $arena_ty {
+                let mut arena: $arena_ty = <$arena_ty>::new();
+                for i in 0..N {
+                    arena.insert(i);
+                }
+                arena
+            }
+
+            #[test]
+            fn par_iter_combinators() {
+                let arena = init_arena();
+                let seq_zip: Vec<_> = arena
+                    .iter()
+                    .map(|(_, v)| *v)
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .zip(0..N)
+                    .map(|(v, i)| v + i)
+                    .collect();
+                let par_zip: Vec<_> = arena
+                    .par_iter()
+                    .map(|(_, v)| *v)
+                    .collect::<Vec<_>>()
+                    .into_par_iter()
+                    .zip((0..N).into_par_iter())
+                    .map(|(v, i)| v + i)
+                    .collect();
+                assert_eq!(seq_zip, par_zip);
+
+                let seq_filter: Vec<_> = arena
+                    .iter()
+                    .filter(|item| *(item.1) % 2 == 0)
+                    .map(|item| *(item.1))
+                    .collect();
+                let par_filter: Vec<_> = arena
+                    .par_iter()
+                    .filter(|item| *(item.1) % 2 == 0)
+                    .map(|item| *(item.1))
+                    .collect();
+                assert_eq!(seq_filter, par_filter);
+
+                let seq_flat_map: Vec<_> = arena
+                    .iter()
+                    .flat_map(|(_, v)| vec![*v, *v + 1])
+                    .collect();
+                let par_flat_map: Vec<_> = arena
+                    .par_iter()
+                    .flat_map(|(_, v)| vec![*v, *v + 1])
+                    .collect();
+                assert_eq!(seq_flat_map, par_flat_map);
+
+                let nested_seq: Vec<Vec<_>> = arena
+                    .iter()
+                    .map(|(_, v)| vec![*v, *v + 1])
+                    .collect();
+                let nested_par: Vec<Vec<_>> = arena
+                    .par_iter()
+                    .map(|(_, v)| vec![*v, *v + 1])
+                    .collect();
+                let seq_flatten: Vec<_> = nested_seq.clone().into_iter().flatten().collect();
+                let par_flatten: Vec<_> = nested_par.into_par_iter().flatten().collect();
+                assert_eq!(seq_flatten, par_flatten);
+
+                let seq_sum: usize = arena.iter().map(|(_, v)| *v).sum();
+                let par_sum: usize = arena
+                    .par_iter()
+                    .fold(|| 0, |acc, (_, v)| acc + *v)
+                    .reduce(|| 0, |a, b| a + b);
+                assert_eq!(seq_sum, par_sum);
+
+                let seq_min = arena.iter().map(|(_, v)| *v).min();
+                let par_min = arena.par_iter().map(|(_, v)| *v).min();
+                assert_eq!(seq_min, par_min);
+
+                let seq_max = arena.iter().map(|(_, v)| *v).max();
+                let par_max = arena.par_iter().map(|(_, v)| *v).max();
+                assert_eq!(seq_max, par_max);
+            }
+
+            #[test]
+            fn par_iter_mut_combinators() {
+                let mut arena = init_arena();
+                let mut values: Vec<_> = arena
+                    .par_iter_mut()
+                    .map(|(_, v)| v)
+                    .collect();
+                values
+                    .into_par_iter()
+                    .zip((0..N).into_par_iter())
+                    .for_each(|(v, i)| *v += i);
+
+                let seq_flat_map: Vec<_> = arena
+                    .iter()
+                    .flat_map(|(_, v)| vec![*v, *v + 1])
+                    .collect();
+                let par_flat_map: Vec<_> = arena
+                    .par_iter_mut()
+                    .flat_map(|(_, v)| vec![*v, *v + 1])
+                    .collect();
+                assert_eq!(seq_flat_map, par_flat_map);
+
+                let seq_sum: usize = arena.iter().map(|(_, v)| *v).sum();
+                let par_sum: usize = arena
+                    .par_iter_mut()
+                    .fold(|| 0, |acc, (_, v)| acc + *v)
+                    .reduce(|| 0, |a, b| a + b);
+                assert_eq!(seq_sum, par_sum);
+
+                let seq_filter: Vec<_> = arena
+                    .iter()
+                    .filter(|item| *(item.1) % 2 == 0)
+                    .map(|item| *(item.1))
+                    .collect();
+                let par_filter: Vec<_> = arena
+                    .par_iter_mut()
+                    .filter(|item| *(item.1) % 2 == 0)
+                    .map(|item| *(item.1))
+                    .collect();
+                assert_eq!(seq_filter, par_filter);
+
+                let seq_min = arena.iter().map(|(_, v)| *v).min();
+                let par_min = arena.par_iter_mut().map(|(_, v)| *v).min();
+                assert_eq!(seq_min, par_min);
+
+                let seq_max = arena.iter().map(|(_, v)| *v).max();
+                let par_max = arena.par_iter_mut().map(|(_, v)| *v).max();
+                assert_eq!(seq_max, par_max);
+
+                let nested_seq: Vec<Vec<_>> = arena.iter().map(|(_, v)| vec![*v]).collect();
+                let nested_par: Vec<Vec<_>> = arena.par_iter_mut().map(|(_, v)| vec![*v]).collect();
+                let seq_flatten: Vec<_> = nested_seq.into_iter().flatten().collect();
+                let par_flatten: Vec<_> = nested_par.into_par_iter().flatten().collect();
+                assert_eq!(seq_flatten, par_flatten);
+            }
+
+            #[test]
+            fn par_sorting() {
+                let mut arena: $arena_ty = <$arena_ty>::new();
+                for i in (0..N).rev() {
+                    arena.insert(i);
+                }
+                let mut expected: Vec<_> = arena.iter().map(|(_, v)| *v).collect();
+                expected.sort();
+
+                let mut v1: Vec<_> = arena.par_iter().map(|(_, v)| *v).collect();
+                v1.par_sort();
+                assert_eq!(v1, expected);
+
+                let mut v2: Vec<_> = arena.par_iter().map(|(_, v)| *v).collect();
+                v2.par_sort_unstable();
+                assert_eq!(v2, expected);
+            }
+        }
+    };
+}
+
+arena_parallel_tests!(generic_arena, Arena<usize>);
+arena_parallel_tests!(u64_arena, U64Arena<usize>);
+arena_parallel_tests!(standard_arena, StandardArena<usize>);
+arena_parallel_tests!(small_arena, SmallArena<usize>);
+arena_parallel_tests!(tiny_arena, TinyArena<usize>);
+arena_parallel_tests!(tiny_wrap_arena, TinyWrapArena<usize>);
+arena_parallel_tests!(nano_arena, NanoArena<usize>);
+arena_parallel_tests!(pico_arena, PicoArena<usize>);
+arena_parallel_tests!(standard_slab, StandardSlab<usize>);
+arena_parallel_tests!(small_slab, SmallSlab<usize>);
+arena_parallel_tests!(ptr_slab, PtrSlab<usize>);
+arena_parallel_tests!(small_ptr_slab, SmallPtrSlab<usize>);

--- a/tests/parallel_combinator_tests.rs
+++ b/tests/parallel_combinator_tests.rs
@@ -21,7 +21,7 @@ macro_rules! arena_parallel_tests {
             }
 
             #[test]
-            fn par_iter_combinators() {
+            fn par_iter_zip() {
                 let arena_a = init_arena();
                 let arena_b = init_arena();
 
@@ -41,59 +41,90 @@ macro_rules! arena_parallel_tests {
                     .collect();
 
                 assert_eq!(seq_zip, par_zip);
+            }
 
-                let seq_filter: Vec<_> = arena_a
+            #[test]
+            fn par_iter_filter() {
+                let arena = init_arena();
+
+                let seq: Vec<_> = arena
                     .iter()
                     .filter(|item| *(item.1) % 2 == 0)
                     .map(|item| *(item.1))
                     .collect();
-                let par_filter: Vec<_> = arena_a
+                let par: Vec<_> = arena
                     .par_iter()
                     .filter(|item| *(item.1) % 2 == 0)
                     .map(|item| *(item.1))
                     .collect();
-                assert_eq!(seq_filter, par_filter);
+                assert_eq!(seq, par);
+            }
 
-                let seq_flat_map: Vec<_> = arena_a
+            #[test]
+            fn par_iter_map() {
+                let arena = init_arena();
+
+                let seq: Vec<_> = arena.iter().map(|(_, v)| v * 2).collect();
+                let par: Vec<_> = arena.par_iter().map(|(_, v)| v * 2).collect();
+                assert_eq!(seq, par);
+            }
+
+            #[test]
+            fn par_iter_flat_map() {
+                let arena = init_arena();
+
+                let seq: Vec<_> = arena
                     .iter()
                     .flat_map(|(_, v)| vec![*v, *v + 1])
                     .collect();
-                let par_flat_map: Vec<_> = arena_a
+                let par: Vec<_> = arena
                     .par_iter()
                     .flat_map(|(_, v)| vec![*v, *v + 1])
                     .collect();
-                assert_eq!(seq_flat_map, par_flat_map);
+                assert_eq!(seq, par);
+            }
 
-                let nested_seq: Vec<Vec<_>> = arena_a
-                    .iter()
-                    .map(|(_, v)| vec![*v, *v + 1])
-                    .collect();
-                let nested_par: Vec<Vec<_>> = arena_a
-                    .par_iter()
-                    .map(|(_, v)| vec![*v, *v + 1])
-                    .collect();
-                let seq_flatten: Vec<_> = nested_seq.clone().into_iter().flatten().collect();
-                let par_flatten: Vec<_> = nested_par.into_par_iter().flatten().collect();
-                assert_eq!(seq_flatten, par_flatten);
+            #[test]
+            fn par_iter_flatten() {
+                let arena = init_arena();
+                let nested_seq: Vec<Vec<_>> =
+                    arena.iter().map(|(_, v)| vec![*v, *v + 1]).collect();
+                let nested_par: Vec<Vec<_>> =
+                    arena.par_iter().map(|(_, v)| vec![*v, *v + 1]).collect();
+                let seq: Vec<_> = nested_seq.clone().into_iter().flatten().collect();
+                let par: Vec<_> = nested_par.into_par_iter().flatten().collect();
+                assert_eq!(seq, par);
+            }
 
-                let seq_sum: usize = arena_a.iter().map(|(_, v)| *v).sum();
-                let par_sum: usize = arena_a
+            #[test]
+            fn par_iter_fold_reduce() {
+                let arena = init_arena();
+                let seq_sum: usize = arena.iter().map(|(_, v)| *v).sum();
+                let par_sum: usize = arena
                     .par_iter()
                     .fold(|| 0, |acc, (_, v)| acc + *v)
                     .reduce(|| 0, |a, b| a + b);
                 assert_eq!(seq_sum, par_sum);
-
-                let seq_min = arena_a.iter().map(|(_, v)| *v).min();
-                let par_min = arena_a.par_iter().map(|(_, v)| *v).min();
-                assert_eq!(seq_min, par_min);
-
-                let seq_max = arena_a.iter().map(|(_, v)| *v).max();
-                let par_max = arena_a.par_iter().map(|(_, v)| *v).max();
-                assert_eq!(seq_max, par_max);
             }
 
             #[test]
-            fn par_iter_mut_combinators() {
+            fn par_iter_min() {
+                let arena = init_arena();
+                let seq = arena.iter().map(|(_, v)| *v).min();
+                let par = arena.par_iter().map(|(_, v)| *v).min();
+                assert_eq!(seq, par);
+            }
+
+            #[test]
+            fn par_iter_max() {
+                let arena = init_arena();
+                let seq = arena.iter().map(|(_, v)| *v).max();
+                let par = arena.par_iter().map(|(_, v)| *v).max();
+                assert_eq!(seq, par);
+            }
+
+            #[test]
+            fn par_iter_mut_zip() {
                 let mut arena_a = init_arena();
                 let arena_b = init_arena();
 
@@ -104,58 +135,91 @@ macro_rules! arena_parallel_tests {
                     .zip(right.into_par_iter())
                     .for_each(|(a, b)| *a += b);
 
-                let mut seq_arena_a = init_arena();
-                let seq_arena_b = init_arena();
-                for ((_, a), (_, b)) in seq_arena_a.iter_mut().zip(seq_arena_b.iter()) {
+                let mut seq_a = init_arena();
+                let seq_b = init_arena();
+                for ((_, a), (_, b)) in seq_a.iter_mut().zip(seq_b.iter()) {
                     *a += *b;
                 }
 
                 let par_result: Vec<_> = arena_a.iter().map(|(_, v)| *v).collect();
-                let seq_result: Vec<_> = seq_arena_a.iter().map(|(_, v)| *v).collect();
+                let seq_result: Vec<_> = seq_a.iter().map(|(_, v)| *v).collect();
                 assert_eq!(par_result, seq_result);
+            }
 
-                let seq_flat_map: Vec<_> = arena_a
+            #[test]
+            fn par_iter_mut_filter() {
+                let mut arena = init_arena();
+                let seq: Vec<_> = arena
+                    .iter()
+                    .filter(|item| *(item.1) % 2 == 0)
+                    .map(|item| *(item.1))
+                    .collect();
+                let par: Vec<_> = arena
+                    .par_iter_mut()
+                    .filter(|item| *(item.1) % 2 == 0)
+                    .map(|item| *(item.1))
+                    .collect();
+                assert_eq!(seq, par);
+            }
+
+            #[test]
+            fn par_iter_mut_map() {
+                let mut arena = init_arena();
+                arena.par_iter_mut().for_each(|(_, v)| *v *= 2);
+                let values: Vec<_> = arena.iter().map(|(_, v)| *v).collect();
+                assert_eq!(values, (0..N).map(|x| x * 2).collect::<Vec<_>>());
+            }
+
+            #[test]
+            fn par_iter_mut_flat_map() {
+                let mut arena = init_arena();
+
+                let seq: Vec<_> = arena
                     .iter()
                     .flat_map(|(_, v)| vec![*v, *v + 1])
                     .collect();
-                let par_flat_map: Vec<_> = arena_a
+                let par: Vec<_> = arena
                     .par_iter_mut()
                     .flat_map(|(_, v)| vec![*v, *v + 1])
                     .collect();
-                assert_eq!(seq_flat_map, par_flat_map);
+                assert_eq!(seq, par);
+            }
 
-                let seq_sum: usize = arena_a.iter().map(|(_, v)| *v).sum();
-                let par_sum: usize = arena_a
+            #[test]
+            fn par_iter_mut_flatten() {
+                let mut arena = init_arena();
+                let nested_seq: Vec<Vec<_>> = arena.iter().map(|(_, v)| vec![*v]).collect();
+                let nested_par: Vec<Vec<_>> = arena.par_iter_mut().map(|(_, v)| vec![*v]).collect();
+                let seq: Vec<_> = nested_seq.into_iter().flatten().collect();
+                let par: Vec<_> = nested_par.into_par_iter().flatten().collect();
+                assert_eq!(seq, par);
+            }
+
+            #[test]
+            fn par_iter_mut_fold_reduce() {
+                let mut arena = init_arena();
+                let seq_sum: usize = arena.iter().map(|(_, v)| *v).sum();
+                let par_sum: usize = arena
                     .par_iter_mut()
                     .fold(|| 0, |acc, (_, v)| acc + *v)
                     .reduce(|| 0, |a, b| a + b);
                 assert_eq!(seq_sum, par_sum);
+            }
 
-                let seq_filter: Vec<_> = arena_a
-                    .iter()
-                    .filter(|item| *(item.1) % 2 == 0)
-                    .map(|item| *(item.1))
-                    .collect();
-                let par_filter: Vec<_> = arena_a
-                    .par_iter_mut()
-                    .filter(|item| *(item.1) % 2 == 0)
-                    .map(|item| *(item.1))
-                    .collect();
-                assert_eq!(seq_filter, par_filter);
+            #[test]
+            fn par_iter_mut_min() {
+                let mut arena = init_arena();
+                let seq = arena.iter().map(|(_, v)| *v).min();
+                let par = arena.par_iter_mut().map(|(_, v)| *v).min();
+                assert_eq!(seq, par);
+            }
 
-                let seq_min = arena_a.iter().map(|(_, v)| *v).min();
-                let par_min = arena_a.par_iter_mut().map(|(_, v)| *v).min();
-                assert_eq!(seq_min, par_min);
-
-                let seq_max = arena_a.iter().map(|(_, v)| *v).max();
-                let par_max = arena_a.par_iter_mut().map(|(_, v)| *v).max();
-                assert_eq!(seq_max, par_max);
-
-                let nested_seq: Vec<Vec<_>> = arena_a.iter().map(|(_, v)| vec![*v]).collect();
-                let nested_par: Vec<Vec<_>> = arena_a.par_iter_mut().map(|(_, v)| vec![*v]).collect();
-                let seq_flatten: Vec<_> = nested_seq.into_iter().flatten().collect();
-                let par_flatten: Vec<_> = nested_par.into_par_iter().flatten().collect();
-                assert_eq!(seq_flatten, par_flatten);
+            #[test]
+            fn par_iter_mut_max() {
+                let mut arena = init_arena();
+                let seq = arena.iter().map(|(_, v)| *v).max();
+                let par = arena.par_iter_mut().map(|(_, v)| *v).max();
+                assert_eq!(seq, par);
             }
 
             #[test]


### PR DESCRIPTION
## Summary
- add parallel iterator tests for base arena and all presets

## Testing
- `cargo test --test parallel_combinator_tests --no-fail-fast`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68586a7132c88323b4fddb1bd9647907