### PR TITLE
Enable Rayon by default and restructure parallel iter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ version = "0.1.0"
 cfg-if = "1.0"
 num-traits = { version = "0.2", default-features = false }
 nonzero_ext = "0.3"
-im = "15.1.0"
-rayon = { version = "1.10", optional = true }
+im = { version = "15.1.0", features = ["rayon"] }
+rayon = "1.10"
 
 [dev-dependencies]
 quickcheck = "1.0"
@@ -29,9 +29,8 @@ path = "benches/benches.rs"
 harness = false
 
 [features]
-default = ["std", "rayon"]
+default = ["std"]
 std = ["num-traits/std"]
-rayon = ["im/rayon", "dep:rayon"]
 
 [profile.bench]
 debug = true

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -13,14 +13,14 @@ use im::Vector;
 #[derive(Clone, Debug)]
 pub struct Arena<T: Clone, I: Clone = usize, G: Clone = usize> {
     // It is a breaking change to modify these three members, as they are needed for serialization
-    items: Vector<Entry<T, I, G>>,
+    pub(crate) items: Vector<Entry<T, I, G>>,
     generation: G,
     len: usize,
     free_list_head: Option<I>,
 }
 
 #[derive(Clone, Debug)]
-enum Entry<T, I = usize, G = u64> {
+pub(crate) enum Entry<T, I = usize, G = u64> {
     Free { next_free: Option<I> },
     Occupied { generation: G, value: T },
 }
@@ -989,154 +989,3 @@ impl<T: Clone, I: ArenaIndex, G: FixedGenerationalIndex> ops::IndexMut<Index<T, 
     }
 }
 
-#[cfg(feature = "rayon")]
-pub mod rayon_support {
-    use super::*;
-    use im::vector::rayon::{ParIter as ImParIter, ParIterMut as ImParIterMut};
-    use rayon::iter::{
-        IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator,
-        ParallelIterator,
-    };
-
-    fn entry_to_ref<'a, T: Clone, I: ArenaIndex, G: FixedGenerationalIndex>(
-        (index, entry): (usize, &'a Entry<T, I, G>),
-    ) -> Option<(Index<T, I, G>, &'a T)> {
-        match entry {
-            Entry::Occupied { generation, value } => {
-                Some((Index::new(I::from_idx(index), *generation), value))
-            }
-            _ => None,
-        }
-    }
-
-    fn entry_to_mut<'a, T: Clone, I: ArenaIndex, G: FixedGenerationalIndex>(
-        (index, entry): (usize, &'a mut Entry<T, I, G>),
-    ) -> Option<(Index<T, I, G>, &'a mut T)> {
-        match entry {
-            Entry::Occupied { generation, value } => {
-                Some((Index::new(I::from_idx(index), *generation), value))
-            }
-            _ => None,
-        }
-    }
-
-    /// Parallel iterator over shared references to arena elements.
-    pub struct ParIter<'a, T, I, G>
-    where
-        T: Clone + Send + Sync + 'a,
-        I: ArenaIndex + Send + Sync + 'a,
-        G: FixedGenerationalIndex + Send + Sync + 'a,
-    {
-        inner: rayon::iter::FilterMap<
-            rayon::iter::Enumerate<ImParIter<'a, Entry<T, I, G>>>,
-            fn((usize, &'a Entry<T, I, G>)) -> Option<(Index<T, I, G>, &'a T)>,
-        >,
-    }
-
-    /// Parallel iterator over mutable references to arena elements.
-    pub struct ParIterMut<'a, T, I, G>
-    where
-        T: Clone + Send + Sync + 'a,
-        I: ArenaIndex + Send + Sync + 'a,
-        G: FixedGenerationalIndex + Send + Sync + 'a,
-    {
-        inner: rayon::iter::FilterMap<
-            rayon::iter::Enumerate<ImParIterMut<'a, Entry<T, I, G>>>,
-            fn((usize, &'a mut Entry<T, I, G>)) -> Option<(Index<T, I, G>, &'a mut T)>,
-        >,
-    }
-
-    impl<'a, T, I, G> core::fmt::Debug for ParIter<'a, T, I, G>
-    where
-        T: Clone + Send + Sync + 'a,
-        I: ArenaIndex + Send + Sync + 'a,
-        G: FixedGenerationalIndex + Send + Sync + 'a,
-    {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            f.debug_struct("ParIter").finish()
-        }
-    }
-
-    impl<'a, T, I, G> core::fmt::Debug for ParIterMut<'a, T, I, G>
-    where
-        T: Clone + Send + Sync + 'a,
-        I: ArenaIndex + Send + Sync + 'a,
-        G: FixedGenerationalIndex + Send + Sync + 'a,
-    {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            f.debug_struct("ParIterMut").finish()
-        }
-    }
-
-    impl<'a, T, I, G> ParallelIterator for ParIter<'a, T, I, G>
-    where
-        T: Clone + Send + Sync + 'a,
-        I: ArenaIndex + Send + Sync + 'a,
-        G: FixedGenerationalIndex + Send + Sync + 'a,
-    {
-        type Item = (Index<T, I, G>, &'a T);
-
-        fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where
-            C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
-        {
-            self.inner.drive_unindexed(consumer)
-        }
-    }
-
-    impl<'a, T, I, G> ParallelIterator for ParIterMut<'a, T, I, G>
-    where
-        T: Clone + Send + Sync + 'a,
-        I: ArenaIndex + Send + Sync + 'a,
-        G: FixedGenerationalIndex + Send + Sync + 'a,
-    {
-        type Item = (Index<T, I, G>, &'a mut T);
-
-        fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where
-            C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
-        {
-            self.inner.drive_unindexed(consumer)
-        }
-    }
-
-    impl<'a, T, I, G> IntoParallelRefIterator<'a> for Arena<T, I, G>
-    where
-        T: Clone + Send + Sync + 'a,
-        I: ArenaIndex + Send + Sync + 'a,
-        G: FixedGenerationalIndex + Send + Sync + 'a,
-    {
-        type Item = (Index<T, I, G>, &'a T);
-        type Iter = ParIter<'a, T, I, G>;
-
-        fn par_iter(&'a self) -> <Self as IntoParallelRefIterator<'a>>::Iter {
-            ParIter {
-                inner: self
-                    .items
-                    .par_iter()
-                    .enumerate()
-                    .filter_map(entry_to_ref::<T, I, G>),
-            }
-        }
-    }
-
-    impl<'a, T, I, G> IntoParallelRefMutIterator<'a> for Arena<T, I, G>
-    where
-        T: Clone + Send + Sync + 'a,
-        I: ArenaIndex + Send + Sync + 'a,
-        G: FixedGenerationalIndex + Send + Sync + 'a,
-    {
-        type Item = (Index<T, I, G>, &'a mut T);
-        type Iter = ParIterMut<'a, T, I, G>;
-
-        fn par_iter_mut(&'a mut self) -> <Self as IntoParallelRefMutIterator<'a>>::Iter {
-            ParIterMut {
-                inner: self
-                    .items
-                    .par_iter_mut()
-                    .enumerate()
-                    .filter_map(entry_to_mut::<T, I, G>),
-            }
-        }
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,6 @@ extern crate num_traits;
 #[macro_use]
 extern crate cfg_if;
 extern crate im;
-#[cfg(feature = "rayon")]
 extern crate rayon;
 
 cfg_if! {
@@ -179,6 +178,8 @@ pub use presets::*;
 mod arena;
 mod generation;
 mod index;
+#[path = "rayon.rs"]
+mod rayon_support;
 
 pub use arena::{Arena, Drain, IntoIter, Iter, IterMut};
 pub use generation::{

--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -1,0 +1,150 @@
+use crate::arena::{Arena, Entry};
+use crate::generation::FixedGenerationalIndex;
+use crate::index::{ArenaIndex, Index};
+use im::vector::rayon::{ParIter as ImParIter, ParIterMut as ImParIterMut};
+use rayon::iter::{
+    IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator,
+    ParallelIterator, IndexedParallelIterator,
+};
+
+fn entry_to_ref<'a, T: Clone, I: ArenaIndex, G: FixedGenerationalIndex>(
+    (index, entry): (usize, &'a Entry<T, I, G>),
+) -> Option<(Index<T, I, G>, &'a T)> {
+    match entry {
+        Entry::Occupied { generation, value } => {
+            Some((Index::new(I::from_idx(index), *generation), value))
+        }
+        _ => None,
+    }
+}
+
+fn entry_to_mut<'a, T: Clone, I: ArenaIndex, G: FixedGenerationalIndex>(
+    (index, entry): (usize, &'a mut Entry<T, I, G>),
+) -> Option<(Index<T, I, G>, &'a mut T)> {
+    match entry {
+        Entry::Occupied { generation, value } => {
+            Some((Index::new(I::from_idx(index), *generation), value))
+        }
+        _ => None,
+    }
+}
+
+/// Parallel iterator over shared references to arena elements.
+pub struct ParIter<'a, T, I, G>
+where
+    T: Clone + Send + Sync + 'a,
+    I: ArenaIndex + Send + Sync + 'a,
+    G: FixedGenerationalIndex + Send + Sync + 'a,
+{
+    inner: rayon::iter::FilterMap<
+        rayon::iter::Enumerate<ImParIter<'a, Entry<T, I, G>>>,
+        fn((usize, &'a Entry<T, I, G>)) -> Option<(Index<T, I, G>, &'a T)>,
+    >,
+}
+
+/// Parallel iterator over mutable references to arena elements.
+pub struct ParIterMut<'a, T, I, G>
+where
+    T: Clone + Send + Sync + 'a,
+    I: ArenaIndex + Send + Sync + 'a,
+    G: FixedGenerationalIndex + Send + Sync + 'a,
+{
+    inner: rayon::iter::FilterMap<
+        rayon::iter::Enumerate<ImParIterMut<'a, Entry<T, I, G>>>,
+        fn((usize, &'a mut Entry<T, I, G>)) -> Option<(Index<T, I, G>, &'a mut T)>,
+    >,
+}
+
+impl<'a, T, I, G> core::fmt::Debug for ParIter<'a, T, I, G>
+where
+    T: Clone + Send + Sync + 'a,
+    I: ArenaIndex + Send + Sync + 'a,
+    G: FixedGenerationalIndex + Send + Sync + 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ParIter").finish()
+    }
+}
+
+impl<'a, T, I, G> core::fmt::Debug for ParIterMut<'a, T, I, G>
+where
+    T: Clone + Send + Sync + 'a,
+    I: ArenaIndex + Send + Sync + 'a,
+    G: FixedGenerationalIndex + Send + Sync + 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ParIterMut").finish()
+    }
+}
+
+impl<'a, T, I, G> ParallelIterator for ParIter<'a, T, I, G>
+where
+    T: Clone + Send + Sync + 'a,
+    I: ArenaIndex + Send + Sync + 'a,
+    G: FixedGenerationalIndex + Send + Sync + 'a,
+{
+    type Item = (Index<T, I, G>, &'a T);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.inner.drive_unindexed(consumer)
+    }
+}
+
+impl<'a, T, I, G> ParallelIterator for ParIterMut<'a, T, I, G>
+where
+    T: Clone + Send + Sync + 'a,
+    I: ArenaIndex + Send + Sync + 'a,
+    G: FixedGenerationalIndex + Send + Sync + 'a,
+{
+    type Item = (Index<T, I, G>, &'a mut T);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.inner.drive_unindexed(consumer)
+    }
+}
+
+impl<'a, T, I, G> IntoParallelIterator for &'a Arena<T, I, G>
+where
+    T: Clone + Send + Sync + 'a,
+    I: ArenaIndex + Send + Sync + 'a,
+    G: FixedGenerationalIndex + Send + Sync + 'a,
+{
+    type Item = (Index<T, I, G>, &'a T);
+    type Iter = ParIter<'a, T, I, G>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        ParIter {
+            inner: self
+                .items
+                .par_iter()
+                .enumerate()
+                .filter_map(entry_to_ref::<T, I, G>),
+        }
+    }
+}
+
+impl<'a, T, I, G> IntoParallelIterator for &'a mut Arena<T, I, G>
+where
+    T: Clone + Send + Sync + 'a,
+    I: ArenaIndex + Send + Sync + 'a,
+    G: FixedGenerationalIndex + Send + Sync + 'a,
+{
+    type Item = (Index<T, I, G>, &'a mut T);
+    type Iter = ParIterMut<'a, T, I, G>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        ParIterMut {
+            inner: self
+                .items
+                .par_iter_mut()
+                .enumerate()
+                .filter_map(entry_to_mut::<T, I, G>),
+        }
+    }
+}

--- a/tests/parallel_tests.rs
+++ b/tests/parallel_tests.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "rayon")]
 
 extern crate generational_arena_im;
 extern crate rayon;


### PR DESCRIPTION
## Summary
- enable rayon unconditionally
- split rayon implementations into a new `rayon.rs` module
- implement `IntoParallelIterator` for `&Arena` and `&mut Arena`
- remove feature gate from parallel tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68587b73bfbc8323b3a2500593541599